### PR TITLE
fix AV relation, view, and doc-backed row automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,49 @@ v2 reduces the tool surface from 70 tools to **17**, because LLMs perform better
 
 ---
 
-## 17 Tools
+## Tool Surface
 
-| # | Tool | What it does |
-|---|------|-------------|
-| 1 | `siyuan_sql` | Run any SQL query on SiYuan's SQLite — replaces 15+ read tools (search, tags, backlinks, blocks, docs) |
-| 2 | `read_database` | Read an AV database (fields + entries), list all databases, filter entries, or get a single entry |
-| 3 | `workspace_map` | Get all notebook IDs, document tree (2 levels), and database IDs in one call |
-| 4 | `create_document` | Create a document or subdocument (nested path: `/Parent/Child`) |
-| 5 | `update_document` | Rename, replace content, and/or move a document |
-| 6 | `delete_document` | Delete a document (with cascade + dryRun support) |
-| 7 | `insert_block` | Insert a block (markdown, heading, list, code, etc.) |
-| 8 | `update_block` | Update a block's content |
-| 9 | `batch_block_ops` | Batch insert/update/delete blocks in one call |
-| 10 | `create_database` | Create an AV database (standalone or embedded in a document) |
-| 11 | `write_db_rows` | Create one or more entries in a database |
-| 12 | `update_db_cells` | Update cells across one or more entries |
-| 13 | `delete_db_rows` | Delete entries from a database |
-| 14 | `manage_db_fields` | Add or remove fields (columns) in a database |
-| 15 | `set_block_attrs` | Set custom attributes on any block |
-| 16 | `upload_asset` | Upload a file (base64) to the workspace |
-| 17 | `list_notebooks` | List notebooks (optionally create one) |
+### Core tools
 
-**Supported AV field types (read/write):** `text`, `number`, `checkbox`, `select`, `mSelect`, `date`, `url`, `email`, `phone`, `mAsset`
+| Tool | What it does |
+|------|-------------|
+| `siyuan_sql` | Run SQL reads against SiYuan's SQLite for blocks, docs, tags, backlinks, and search |
+| `read_database` | Read an AV database, list databases, filter entries, or fetch a single entry |
+| `workspace_map` | Get all notebook IDs, document tree (2 levels), and database IDs in one call |
+| `create_document` | Create a document or subdocument (nested path: `/Parent/Child`) |
+| `update_document` | Rename, replace content, and/or move a document |
+| `delete_document` | Delete a document (with cascade + dryRun support) |
+| `insert_block` | Insert a block (markdown, heading, list, code, etc.) |
+| `update_block` | Update a block's content |
+| `batch_block_ops` | Batch insert/update/delete blocks in one call |
+| `create_database` | Create an AV database (standalone or embedded in a document) |
+| `write_db_rows` | Create one or more entries in a database |
+| `update_db_cells` | Update cells across one or more entries |
+| `delete_db_rows` | Delete entries from a database |
+| `manage_db_fields` | Add or remove fields (columns) in a database |
+| `set_block_attrs` | Set custom attributes on any block |
+| `upload_asset` | Upload a file (base64) to the workspace |
+| `list_notebooks` | List notebooks (optionally create one) |
 
-**System fields (read-only):** `created`, `updated`, `lineNumber`, `template`, `rollup`, `relation`
+### New database automation tools
+
+| Tool | What it does |
+|------|-------------|
+| `list_views` | List database views with current layout, grouping, filters, and sorts |
+| `add_view` | Add a table, kanban, or gallery view |
+| `update_view` | Change a view's layout, name, grouping, filters, or sorts |
+| `delete_view` | Remove a database view |
+| `bind_row_to_doc` | Convert an existing detached row into a document-backed row |
+| `create_doc_backed_row` | Create a document and add it as a document-backed database row |
+| `list_select_options` | List the current options for a select/multi-select field |
+| `set_select_options` | Define or update the options for a select/multi-select field |
+| `rename_notebook` | Rename a notebook by ID |
+
+**Supported AV field types (create/write):** `text`, `number`, `checkbox`, `select`, `mSelect`, `date`, `url`, `email`, `phone`, `mAsset`, `relation`
+
+**Supported AV field types (create/configure):** `relation`, `rollup`
+
+**Read-only/system-computed field types:** `created`, `updated`, `lineNumber`, `template`
 
 ---
 
@@ -180,6 +198,28 @@ The server exposes static guides as MCP resources:
 Read them in your MCP client to get detailed usage guidance.
 
 ---
+
+## Consumer smoke test
+
+After building, you can validate the full issue-#1 database automation flow against a live SiYuan instance:
+
+```bash
+SIYUAN_API_TOKEN=your-token-here npm run smoke:siyuan
+```
+
+The smoke test creates a temporary notebook, exercises:
+- relation field creation with back-reference
+- rollup field creation and readback
+- relation cell writes
+- view add/update
+- select option management
+- detached row → document binding
+- document-backed row creation
+- notebook rename
+
+Then it removes the temporary notebook.
+
+Tested live against SiYuan `3.6.4`.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "siyuan-query-mcp",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "siyuan-query-mcp",
-      "version": "1.0.7",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run --coverage",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "smoke:siyuan": "node scripts/siyuan-issue1-smoke.js"
   },
   "keywords": [
     "mcp",

--- a/scripts/siyuan-issue1-smoke.js
+++ b/scripts/siyuan-issue1-smoke.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+const { createSiyuanClient } = require('../dist/siyuanClient');
+const { AttributeViewService } = require('../dist/services/av-service');
+
+async function main() {
+  const token = process.env.SIYUAN_API_TOKEN || process.env.SIYUAN_TOKEN;
+  if (!token) {
+    throw new Error('Set SIYUAN_API_TOKEN before running the smoke test');
+  }
+
+  const client = createSiyuanClient({ autoDiscoverPort: true, token });
+  const avService = new AttributeViewService(client);
+  const stamp = `MCP Smoke ${Date.now()}`;
+
+  const notebookResp = await client.request('/api/notebook/createNotebook', { name: stamp });
+  if (!notebookResp || notebookResp.code !== 0) {
+    throw new Error(`createNotebook failed: ${notebookResp?.msg ?? 'unknown error'}`);
+  }
+
+  const notebookId = notebookResp.data.notebook.id;
+
+  try {
+    const tasksDb = await avService.createDatabase(notebookId, `${stamp} Tasks`, [
+      { name: 'Status', type: 'select' },
+      { name: 'Estimate', type: 'number' }
+    ]);
+    const reposDb = await avService.createDatabase(notebookId, `${stamp} Repos`, []);
+
+    const tasksInitial = await avService.renderDatabase(tasksDb.avId);
+    const estimateField = tasksInitial.fields.find(field => field.name === 'Estimate');
+    const statusField = tasksInitial.fields.find(field => field.name === 'Status');
+    const nameField = tasksInitial.fields.find(field => field.name === 'Name');
+    if (!estimateField || !statusField || !nameField) {
+      throw new Error('Required initial fields were not found');
+    }
+
+    const relationField = await avService.createRelationField(tasksDb.avId, 'Repo Link', {
+      targetAvId: reposDb.avId,
+      backRef: true,
+      backRefName: 'Tasks'
+    });
+
+    const reposAfterRelation = await avService.renderDatabase(reposDb.avId);
+    const repoBackRef = reposAfterRelation.fields.find(field => field.name === 'Tasks');
+    if (!repoBackRef) {
+      throw new Error('Back-reference relation field was not created');
+    }
+
+    await avService.createRollupField(reposDb.avId, 'Task Count', {
+      relationFieldId: repoBackRef.id,
+      targetFieldId: nameField.id,
+      calc: 'count'
+    });
+
+    const repoRow = await avService.bulkCreateEntries(reposDb.avId, [{ name: 'repo-a' }]);
+    const taskRow = await avService.bulkCreateEntries(tasksDb.avId, [{
+      name: 'task-a',
+      values: [
+        { fieldId: estimateField.id, type: 'number', content: 5 },
+        { fieldId: statusField.id, type: 'select', content: 'Todo' }
+      ]
+    }]);
+
+    await avService.bulkUpdateEntries(tasksDb.avId, [{
+      entryId: taskRow[0].id,
+      changes: [{ fieldId: relationField.id, type: 'relation', content: [repoRow[0].id] }]
+    }]);
+
+    const taskRead = await avService.getEntry(tasksDb.avId, taskRow[0].id);
+    if (taskRead.cells['Repo Link']?.ids?.[0] !== repoRow[0].id) {
+      throw new Error('Relation write did not round-trip');
+    }
+
+    const repoRead = await avService.getEntry(reposDb.avId, repoRow[0].id);
+    if (!Array.isArray(repoRead.cells['Task Count']) || repoRead.cells['Task Count'][0]?.block?.content !== 'task-a') {
+      throw new Error('Rollup readback did not return the related task row');
+    }
+
+    const addedView = await avService.addView(tasksDb.avId, {
+      type: 'kanban',
+      name: 'By Repo',
+      groupByFieldId: relationField.id
+    });
+    await avService.updateView(tasksDb.avId, addedView.id, {
+      name: 'By Repo Updated',
+      sorts: [{ column: estimateField.id, order: 1 }]
+    });
+
+    const view = (await avService.listViews(tasksDb.avId)).find(item => item.id === addedView.id);
+    if (!view || view.name !== 'By Repo Updated') {
+      throw new Error('View update did not persist');
+    }
+
+    const selectOptions = await avService.setSelectOptions(tasksDb.avId, statusField.id, [
+      { name: 'Todo', color: '1', desc: 'Todo work' },
+      { name: 'Doing', color: '2', desc: 'In progress' }
+    ]);
+    if (selectOptions.length !== 2) {
+      throw new Error('Select option update did not persist');
+    }
+
+    const bindDocResp = await client.request('/api/filetree/createDocWithMd', {
+      notebook: notebookId,
+      path: `/${stamp}-bind-doc`,
+      markdown: '# Bound Row'
+    });
+    const detachedRows = await avService.bulkCreateEntries(tasksDb.avId, [{ name: 'detached-row' }]);
+    const boundRow = await avService.bindRowToDoc(tasksDb.avId, detachedRows[0].id, bindDocResp.data);
+    if (boundRow.cells.Name.id !== bindDocResp.data || boundRow.cells.Name.isDetached !== false) {
+      throw new Error('bind_row_to_doc did not persist');
+    }
+
+    const docBackedRow = await avService.createDocBackedRow(
+      tasksDb.avId,
+      notebookId,
+      `/${stamp}-doc-backed-row`,
+      'Doc Backed Row',
+      '# Body',
+      [{ fieldId: estimateField.id, type: 'number', content: 8 }]
+    );
+    if (docBackedRow.cells.Name.isDetached !== false || docBackedRow.cells.Estimate !== 8) {
+      throw new Error('create_doc_backed_row did not persist');
+    }
+
+    const renameResp = await client.request('/api/notebook/renameNotebook', {
+      notebook: notebookId,
+      name: `${stamp} Renamed`
+    });
+    if (!renameResp || renameResp.code !== 0) {
+      throw new Error(`renameNotebook failed: ${renameResp?.msg ?? 'unknown error'}`);
+    }
+
+    console.log(JSON.stringify({ ok: true, notebookId, tasksDb, reposDb }, null, 2));
+  } finally {
+    await client.request('/api/notebook/removeNotebook', { notebook: notebookId }).catch(() => {});
+  }
+}
+
+main().catch(error => {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});

--- a/src/services/av-service.test.ts
+++ b/src/services/av-service.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { AttributeViewService } from './av-service';
+
+describe('AttributeViewService', () => {
+  it('buildUpdateValue encodes relation writes with blockIDs', () => {
+    const service = new AttributeViewService({} as any);
+    const result = (service as any).buildUpdateValue({
+      fieldId: 'repo',
+      type: 'relation',
+      content: ['row-b', 'row-c']
+    });
+
+    expect(result).toEqual({
+      relation: {
+        blockIDs: ['row-b', 'row-c']
+      }
+    });
+  });
+
+  it('maps supported rollup calc names to SiYuan operators', () => {
+    const service = new AttributeViewService({} as any);
+
+    expect((service as any).mapRollupCalcOperator('count')).toBe('CountAll');
+    expect((service as any).mapRollupCalcOperator('countDistinct')).toBe('CountUniqueValues');
+    expect((service as any).mapRollupCalcOperator('sum')).toBe('Sum');
+    expect((service as any).mapRollupCalcOperator('avg')).toBe('Average');
+    expect((service as any).mapRollupCalcOperator('empty')).toBe('CountEmpty');
+    expect((service as any).mapRollupCalcOperator('notEmpty')).toBe('CountNotEmpty');
+    expect((service as any).mapRollupCalcOperator('unique')).toBe('UniqueValues');
+    expect((service as any).mapRollupCalcOperator('checked')).toBe('Checked');
+    expect((service as any).mapRollupCalcOperator('unchecked')).toBe('Unchecked');
+    expect((service as any).mapRollupCalcOperator('percent')).toBe('PercentNotEmpty');
+    expect((service as any).mapRollupCalcOperator(undefined)).toBe('None');
+  });
+});

--- a/src/services/av-service.ts
+++ b/src/services/av-service.ts
@@ -11,7 +11,7 @@
  */
 
 import { SiyuanClient } from '../siyuanClient';
-import { parseColumns, parseRow, findColumn } from '../utils/avParser';
+import { parseCellValue, parseColumns, parseRow, findColumn } from '../utils/avParser';
 
 // ==================== Types publics ====================
 
@@ -19,6 +19,20 @@ export interface AVColumn {
   id: string;
   name: string;
   type: string;
+  options?: any[];
+  relation?: {
+    avID?: string;
+    isTwoWay?: boolean;
+    backKeyID?: string;
+  };
+  rollup?: {
+    relationKeyID?: string;
+    keyID?: string;
+    calc?: {
+      operator?: string;
+      result?: any;
+    };
+  };
 }
 
 export interface AVField {
@@ -26,6 +40,50 @@ export interface AVField {
   name: string;
   type: string;
   options?: any[];
+  relation?: {
+    avID?: string;
+    isTwoWay?: boolean;
+    backKeyID?: string;
+  };
+  rollup?: {
+    relationKeyID?: string;
+    keyID?: string;
+    calc?: {
+      operator?: string;
+      result?: any;
+    };
+  };
+}
+
+export interface AVRelationConfig {
+  targetAvId: string;
+  backRef?: boolean;
+  backRefName?: string;
+}
+
+export interface AVRollupConfig {
+  relationFieldId: string;
+  targetFieldId: string;
+  calc?: string;
+}
+
+export interface AVViewSummary {
+  id: string;
+  name: string;
+  type: string;
+  icon?: string;
+  desc?: string;
+  groupByFieldId?: string;
+  filters?: any[];
+  sorts?: any[];
+}
+
+export interface AVViewConfig {
+  name?: string;
+  type?: 'table' | 'kanban' | 'gallery';
+  groupByFieldId?: string;
+  filters?: any[];
+  sorts?: any[];
 }
 
 export interface AVRow {
@@ -263,14 +321,13 @@ export class AttributeViewService {
   ): Promise<AVRow | null> {
     if (!avId?.trim()) throw new Error('avId is required');
 
-    // Get current entries to identify the new one after creation
-    const before = await this.renderDatabase(avId);
-    const beforeIds = new Set(before.entries.map((r: AVRow) => r.id));
-    const pkField = before.fields.find((f: AVColumn) => f.type === 'block');
+    const beforeModel = await this.loadAttributeViewModel(avId);
+    const beforeIds = new Set(this.collectModelEntryIds(beforeModel));
+    const beforeFields = parseColumns((beforeModel?.keyValues ?? []).map((kv: any) => kv.key));
+    const pkField = beforeFields.find((f: AVColumn) => f.type === 'block');
     if (!pkField) throw new Error('Primary field (block type) not found in this database');
 
-    // Build the 2D cell array for this single row
-    const row = this.buildAppendRow(pkField.id, name, values, before.fields);
+    const row = this.buildAppendRow(pkField.id, name, values, beforeFields);
 
     const response = await this.client.request('/api/av/appendAttributeViewDetachedBlocksWithValues', {
       avID: avId.trim(),
@@ -281,9 +338,9 @@ export class AttributeViewService {
       throw new Error(`Failed to create entry: ${response?.msg ?? 'unknown error'}`);
     }
 
-    // Re-render to get the new entry with its kernel-assigned ID
-    const after = await this.renderDatabase(avId);
-    return after.entries.find((r: AVRow) => !beforeIds.has(r.id)) ?? null;
+    const afterModel = await this.loadAttributeViewModel(avId);
+    const createdId = this.collectModelEntryIds(afterModel).find(id => !beforeIds.has(id));
+    return createdId ? this.buildRowFromModel(afterModel, createdId) : null;
   }
 
   /**
@@ -488,8 +545,15 @@ export class AttributeViewService {
   async getEntry(avId: string, entryId: string): Promise<AVRow | null> {
     if (!avId?.trim()) throw new Error('avId is required');
     if (!entryId?.trim()) throw new Error('entryId is required');
+
     const db = await this.renderDatabase(avId);
-    return db.entries.find((r: AVRow) => r.id === entryId.trim()) ?? null;
+    const renderedRow = db.entries.find((r: AVRow) => r.id === entryId.trim());
+    if (renderedRow) {
+      return renderedRow;
+    }
+
+    const model = await this.loadAttributeViewModel(avId);
+    return this.buildRowFromModel(model, entryId.trim());
   }
 
   /**
@@ -504,14 +568,14 @@ export class AttributeViewService {
     if (!avId?.trim()) throw new Error('avId is required');
     if (!entries?.length) throw new Error('entries array must not be empty');
 
-    const before = await this.renderDatabase(avId);
-    const beforeIds = new Set(before.entries.map((r: AVRow) => r.id));
-    const pkField = before.fields.find((f: AVColumn) => f.type === 'block');
+    const beforeModel = await this.loadAttributeViewModel(avId);
+    const beforeIds = new Set(this.collectModelEntryIds(beforeModel));
+    const beforeFields = parseColumns((beforeModel?.keyValues ?? []).map((kv: any) => kv.key));
+    const pkField = beforeFields.find((f: AVColumn) => f.type === 'block');
     if (!pkField) throw new Error('Primary field (block type) not found in this database');
 
-    // Build 2D array: each element is an array of cells for one row
     const blocksValues = entries.map(entry =>
-      this.buildAppendRow(pkField.id, entry.name ?? '', entry.values ?? [], before.fields)
+      this.buildAppendRow(pkField.id, entry.name ?? '', entry.values ?? [], beforeFields)
     );
 
     const response = await this.client.request('/api/av/appendAttributeViewDetachedBlocksWithValues', {
@@ -523,8 +587,11 @@ export class AttributeViewService {
       throw new Error(`Failed to create entries: ${response?.msg ?? 'unknown error'}`);
     }
 
-    const after = await this.renderDatabase(avId);
-    return after.entries.filter((r: AVRow) => !beforeIds.has(r.id));
+    const afterModel = await this.loadAttributeViewModel(avId);
+    const createdIds = this.collectModelEntryIds(afterModel).filter(id => !beforeIds.has(id));
+    return createdIds
+      .map(id => this.buildRowFromModel(afterModel, id))
+      .filter((row): row is AVRow => row !== null);
   }
 
   /**
@@ -578,7 +645,9 @@ export class AttributeViewService {
       id: f.id,
       name: f.name,
       type: f.type,
-      options: (f as any).options ?? undefined
+      options: f.options ?? undefined,
+      relation: f.relation ?? undefined,
+      rollup: f.rollup ?? undefined
     }));
   }
 
@@ -600,20 +669,20 @@ export class AttributeViewService {
     if (!avId?.trim()) throw new Error('avId is required');
     if (!name?.trim()) throw new Error('name is required');
 
-    const WRITABLE_TYPES = new Set([
+    const CREATABLE_TYPES = new Set([
       'text','number','select','mSelect','date','checkbox',
-      'url','email','phone','mAsset'
+      'url','email','phone','mAsset','relation','rollup'
     ]);
-    const SYSTEM_TYPES = new Set(['relation','rollup','created','updated','lineNumber','template']);
+    const READ_ONLY_TYPES = new Set(['created','updated','lineNumber','template']);
 
     if (type === 'block') {
       throw new Error(`Field type "block" is the primary key and is auto-created. You cannot add a second one.`);
     }
-    if (SYSTEM_TYPES.has(type)) {
+    if (READ_ONLY_TYPES.has(type)) {
       throw new Error(`Field type "${type}" is system-managed and cannot be created via MCP.`);
     }
-    if (!WRITABLE_TYPES.has(type)) {
-      throw new Error(`Unknown field type: "${type}". Valid: ${[...WRITABLE_TYPES].join(', ')}`);
+    if (!CREATABLE_TYPES.has(type)) {
+      throw new Error(`Unknown field type: "${type}". Valid: ${[...CREATABLE_TYPES].join(', ')}`);
     }
 
     // Get current view column order to append the new field at the end.
@@ -709,6 +778,277 @@ export class AttributeViewService {
     }
   }
 
+  async createRelationField(avId: string, name: string, relation: AVRelationConfig): Promise<AVField> {
+    if (!relation?.targetAvId?.trim()) throw new Error('relation.targetAvId is required');
+
+    const field = await this.createField(avId, name, 'relation');
+    const backRelationKeyId = relation.backRef ? this.generateSiyuanId() : '';
+
+    await this.performTransactions([
+      {
+        action: 'updateAttrViewColRelation',
+        avID: avId.trim(),
+        id: relation.targetAvId.trim(),
+        keyID: field.id,
+        isTwoWay: Boolean(relation.backRef),
+        backRelationKeyID: backRelationKeyId,
+        name: relation.backRefName?.trim() || '',
+        format: name.trim()
+      }
+    ]);
+
+    return {
+      id: field.id,
+      name: name.trim(),
+      type: 'relation',
+      relation: {
+        avID: relation.targetAvId.trim(),
+        isTwoWay: Boolean(relation.backRef),
+        backKeyID: backRelationKeyId || undefined
+      }
+    };
+  }
+
+  async createRollupField(avId: string, name: string, rollup: AVRollupConfig): Promise<AVField> {
+    if (!rollup?.relationFieldId?.trim()) throw new Error('rollup.relationFieldId is required');
+    if (!rollup?.targetFieldId?.trim()) throw new Error('rollup.targetFieldId is required');
+
+    const field = await this.createField(avId, name, 'rollup');
+
+    await this.performTransactions([
+      {
+        action: 'updateAttrViewColRollup',
+        avID: avId.trim(),
+        id: field.id,
+        parentID: rollup.relationFieldId.trim(),
+        keyID: rollup.targetFieldId.trim(),
+        data: {
+          calc: {
+            operator: this.mapRollupCalcOperator(rollup.calc)
+          }
+        }
+      }
+    ]);
+
+    return {
+      id: field.id,
+      name: name.trim(),
+      type: 'rollup',
+      rollup: {
+        relationKeyID: rollup.relationFieldId.trim(),
+        keyID: rollup.targetFieldId.trim(),
+        calc: {
+          operator: this.mapRollupCalcOperator(rollup.calc)
+        }
+      }
+    };
+  }
+
+  async listViews(avId: string): Promise<AVViewSummary[]> {
+    const db = await this.renderDatabase(avId);
+    const raw = await this.client.request('/api/av/renderAttributeView', { id: avId.trim() });
+    const views = raw?.data?.views ?? [];
+    const currentView = raw?.data?.view ?? null;
+
+    return views.map((view: any) => {
+      const fullView = currentView && currentView.id === view.id ? currentView : null;
+      return {
+        id: view.id,
+        name: view.name,
+        type: view.type,
+        icon: view.icon ?? '',
+        desc: view.desc ?? '',
+        groupByFieldId: fullView?.group?.field ?? undefined,
+        filters: fullView?.filters ?? [],
+        sorts: fullView?.sorts ?? []
+      };
+    });
+  }
+
+  async addView(avId: string, config: Required<Pick<AVViewConfig, 'type'>> & AVViewConfig): Promise<AVViewSummary> {
+    const blockId = await this.resolveDatabaseBlockId(avId);
+    const viewId = this.generateSiyuanId();
+
+    await this.performTransactions([
+      {
+        action: 'addAttrViewView',
+        avID: avId.trim(),
+        id: viewId,
+        blockID: blockId,
+        layout: config.type
+      }
+    ]);
+
+    const ops: any[] = [];
+    if (config.name?.trim()) {
+      ops.push({ action: 'setAttrViewViewName', avID: avId.trim(), id: viewId, data: config.name.trim() });
+    }
+    if (config.filters) {
+      ops.push({ action: 'setAttrViewFilters', avID: avId.trim(), blockID: blockId, data: config.filters });
+    }
+    if (config.sorts) {
+      ops.push({ action: 'setAttrViewSorts', avID: avId.trim(), blockID: blockId, data: config.sorts });
+    }
+    if (config.groupByFieldId && config.type === 'kanban') {
+      ops.push({
+        action: 'setAttrViewGroup',
+        avID: avId.trim(),
+        blockID: blockId,
+        data: { field: config.groupByFieldId.trim() }
+      });
+    }
+
+    if (ops.length) {
+      await this.performTransactions(ops);
+    }
+
+    const views = await this.listViews(avId);
+    const created = views.find(view => view.id === viewId);
+    if (!created) throw new Error(`Failed to find created view ${viewId}`);
+    return created;
+  }
+
+  async updateView(avId: string, viewId: string, config: AVViewConfig): Promise<AVViewSummary> {
+    const blockId = await this.resolveDatabaseBlockId(avId);
+    const viewBlockId = await this.resolveViewBlockId(avId, viewId, blockId);
+    const ops: any[] = [];
+
+    if (config.type) {
+      ops.push({
+        action: 'changeAttrViewLayout',
+        avID: avId.trim(),
+        blockID: viewBlockId,
+        layout: config.type
+      });
+    }
+    if (config.name?.trim()) {
+      ops.push({ action: 'setAttrViewViewName', avID: avId.trim(), id: viewId.trim(), data: config.name.trim() });
+    }
+    if (config.filters) {
+      ops.push({ action: 'setAttrViewFilters', avID: avId.trim(), blockID: viewBlockId, data: config.filters });
+    }
+    if (config.sorts) {
+      ops.push({ action: 'setAttrViewSorts', avID: avId.trim(), blockID: viewBlockId, data: config.sorts });
+    }
+    if (config.groupByFieldId) {
+      ops.push({
+        action: 'setAttrViewGroup',
+        avID: avId.trim(),
+        blockID: viewBlockId,
+        data: { field: config.groupByFieldId.trim() }
+      });
+    }
+
+    if (!ops.length) throw new Error('No view changes provided');
+    await this.performTransactions(ops);
+
+    const views = await this.listViews(avId);
+    const updated = views.find(view => view.id === viewId.trim());
+    if (!updated) throw new Error(`Failed to find updated view ${viewId}`);
+    return updated;
+  }
+
+  async deleteView(avId: string, viewId: string): Promise<void> {
+    const blockId = await this.resolveViewBlockId(avId, viewId);
+    await this.performTransactions([
+      {
+        action: 'removeAttrViewView',
+        avID: avId.trim(),
+        blockID: blockId
+      }
+    ]);
+  }
+
+  async listSelectOptions(avId: string, fieldId: string): Promise<any[]> {
+    const fields = await this.listFields(avId);
+    const field = fields.find(f => f.id === fieldId.trim());
+    if (!field) throw new Error(`Field "${fieldId}" not found in database`);
+    return field.options ?? [];
+  }
+
+  async setSelectOptions(avId: string, fieldId: string, options: Array<{ name: string; color?: string; desc?: string }>): Promise<any[]> {
+    await this.performTransactions([
+      {
+        action: 'updateAttrViewColOptions',
+        avID: avId.trim(),
+        id: fieldId.trim(),
+        data: options.map(option => ({
+          name: option.name,
+          color: option.color ?? '',
+          desc: option.desc ?? ''
+        }))
+      }
+    ]);
+
+    return this.listSelectOptions(avId, fieldId);
+  }
+
+  async bindRowToDoc(avId: string, entryId: string, docId: string): Promise<AVRow | null> {
+    if (!avId?.trim()) throw new Error('avId is required');
+    if (!entryId?.trim()) throw new Error('entryId is required');
+    if (!docId?.trim()) throw new Error('docId is required');
+
+    const response = await this.client.request('/api/av/batchReplaceAttributeViewBlocks', {
+      avID: avId.trim(),
+      isDetached: false,
+      oldNew: [{ [entryId.trim()]: docId.trim() }]
+    });
+
+    if (!response || response.code !== 0) {
+      throw new Error(`Failed to bind row to document: ${response?.msg ?? 'unknown error'}`);
+    }
+
+    return this.getEntry(avId, entryId);
+  }
+
+  async createDocBackedRow(
+    avId: string,
+    notebookId: string,
+    path: string,
+    title: string,
+    content: string = '',
+    values: AVCreateRowValue[] = []
+  ): Promise<AVRow | null> {
+    const docResp = await this.client.request('/api/filetree/createDocWithMd', {
+      notebook: notebookId.trim(),
+      path,
+      markdown: content
+    });
+
+    if (!docResp || docResp.code !== 0 || !docResp.data) {
+      throw new Error(`Failed to create document-backed row document: ${docResp?.msg ?? 'unknown error'}`);
+    }
+
+    const docId = typeof docResp.data === 'string' ? docResp.data : docResp.data.id;
+    const blockId = await this.resolveDatabaseBlockId(avId);
+
+    const addResp = await this.client.request('/api/av/addAttributeViewBlocks', {
+      avID: avId.trim(),
+      blockID: blockId,
+      srcs: [{ id: docId, content: title.trim(), isDetached: false }]
+    });
+
+    if (!addResp || addResp.code !== 0) {
+      throw new Error(`Failed to create document-backed row: ${addResp?.msg ?? 'unknown error'}`);
+    }
+
+    const itemMapResp = await this.client.request('/api/av/getAttributeViewItemIDsByBoundIDs', {
+      avID: avId.trim(),
+      blockIDs: [docId]
+    });
+
+    const entryId = itemMapResp?.data?.[docId] ?? null;
+    if (!entryId) {
+      throw new Error('Document-backed row was created, but entry ID could not be resolved');
+    }
+
+    if (values.length) {
+      await this.bulkUpdateEntries(avId.trim(), [{ entryId, changes: values }]);
+    }
+
+    return this.getEntry(avId.trim(), entryId);
+  }
+
   // ==================== Helpers privés ====================
 
   /**
@@ -727,6 +1067,132 @@ export class AttributeViewService {
       chars[Math.floor(Math.random() * chars.length)]
     ).join('');
     return `${ts}-${suffix}`;
+  }
+
+  private async performTransactions(operations: any[]): Promise<any> {
+    const response = await this.client.request('/api/transactions', {
+      transactions: [
+        {
+          doOperations: operations,
+          undoOperations: []
+        }
+      ],
+      reqId: Date.now()
+    });
+
+    if (!response || response.code !== 0) {
+      throw new Error(`Transaction failed: ${response?.msg ?? 'unknown error'}`);
+    }
+
+    return response.data;
+  }
+
+  private async resolveDatabaseBlockId(avId: string): Promise<string> {
+    const response = await this.client.request('/api/av/getMirrorDatabaseBlocks', {
+      avID: avId.trim()
+    });
+
+    const refDefs = response?.data?.refDefs ?? [];
+    const first = refDefs[0];
+    if (!first?.refID) {
+      throw new Error(`Could not resolve database block ID for AV ${avId}`);
+    }
+    return first.refID;
+  }
+
+  private async resolveViewBlockId(avId: string, viewId: string, fallbackBlockId?: string): Promise<string> {
+    const blockId = fallbackBlockId ?? await this.resolveDatabaseBlockId(avId);
+    const raw = await this.client.request('/api/av/renderAttributeView', {
+      id: avId.trim(),
+      blockID: blockId
+    });
+
+    const currentViewId = raw?.data?.viewID ?? raw?.data?.view?.id;
+    if (currentViewId === viewId.trim()) {
+      return blockId;
+    }
+
+    await this.performTransactions([
+      {
+        action: 'setAttrViewBlockView',
+        avID: avId.trim(),
+        blockID: blockId,
+        id: viewId.trim()
+      }
+    ]);
+
+    return blockId;
+  }
+
+  private mapRollupCalcOperator(calc?: string): string {
+    switch ((calc ?? 'none').trim()) {
+      case 'count':
+        return 'CountAll';
+      case 'countDistinct':
+        return 'CountUniqueValues';
+      case 'sum':
+        return 'Sum';
+      case 'avg':
+        return 'Average';
+      case 'min':
+        return 'Min';
+      case 'max':
+        return 'Max';
+      case 'empty':
+        return 'CountEmpty';
+      case 'notEmpty':
+        return 'CountNotEmpty';
+      case 'unique':
+        return 'UniqueValues';
+      case 'checked':
+        return 'Checked';
+      case 'unchecked':
+        return 'Unchecked';
+      case 'percent':
+        return 'PercentNotEmpty';
+      default:
+        return 'None';
+    }
+  }
+
+  private async loadAttributeViewModel(avId: string): Promise<any> {
+    const avHttpPath = `/data/storage/av/${avId.trim()}.json`;
+    const model = await this.client.fileGet(avHttpPath);
+    if (!model || typeof model !== 'object') {
+      throw new Error(`Database not found: ${avId}`);
+    }
+    return model;
+  }
+
+  private collectModelEntryIds(model: any): string[] {
+    const blockKeyValues = (model?.keyValues ?? []).find((kv: any) => kv?.key?.type === 'block');
+    const ids = (blockKeyValues?.values ?? []).map((value: any) => value?.blockID).filter(Boolean);
+    return Array.from(new Set(ids));
+  }
+
+  private buildRowFromModel(model: any, entryId: string): AVRow | null {
+    const keyValues: any[] = model?.keyValues ?? [];
+    if (!keyValues.length) {
+      return null;
+    }
+
+    const columns = parseColumns(keyValues.map((kv: any) => kv.key));
+    const cells: Record<string, any> = {};
+
+    for (const kv of keyValues) {
+      const value = (kv?.values ?? []).find((item: any) => item?.blockID === entryId);
+      if (!value || !kv?.key?.id) {
+        continue;
+      }
+      const colId = kv.key.id;
+      const parsed = parseCellValue({ value });
+      cells[colId] = parsed;
+      if (kv.key.name && kv.key.name !== colId) {
+        cells[kv.key.name] = parsed;
+      }
+    }
+
+    return Object.keys(cells).length ? { id: entryId, cells } : null;
   }
 
   /**
@@ -765,13 +1231,20 @@ export class AttributeViewService {
           }))
         };
       }
+      case 'relation': {
+        const items = Array.isArray(v.content) ? v.content : [v.content];
+        return {
+          relation: {
+            blockIDs: items.map((item: any) => String(item))
+          }
+        };
+      }
       // System-managed / computed types — not writable via MCP
       case 'created':
       case 'updated':
       case 'lineNumber':
       case 'template':
       case 'rollup':
-      case 'relation':
         throw new Error(
           `Field type "${v.type}" is system-managed or computed — cannot write a value manually.`
         );
@@ -872,8 +1345,11 @@ export class AttributeViewService {
     }
 
     const view = data.view ?? data;
-    const rawColumns: any[] = view.columns ?? data.columns ?? [];
-    const rawRows: any[]    = view.rows    ?? data.rows    ?? [];
+    const rawColumns: any[] = view.columns ?? view.fields ?? data.columns ?? data.fields ?? [];
+    const groupedRows: any[] = Array.isArray(view.groups)
+      ? view.groups.flatMap((group: any) => group?.rows ?? group?.cards ?? [])
+      : [];
+    const rawRows: any[] = view.rows ?? view.cards ?? groupedRows ?? data.rows ?? data.cards ?? [];
 
     const columns = parseColumns(rawColumns);
 

--- a/src/tools/v2/definitions.ts
+++ b/src/tools/v2/definitions.ts
@@ -257,7 +257,7 @@ export const TOOLS: Tool[] = [
                     fieldId: { type: 'string', description: 'Field ID (from read_database)' },
                     type: {
                       type: 'string',
-                      enum: ['text', 'number', 'checkbox', 'select', 'mSelect', 'date', 'url', 'email', 'phone', 'mAsset'],
+                      enum: ['text', 'number', 'checkbox', 'select', 'mSelect', 'date', 'url', 'email', 'phone', 'mAsset', 'relation'],
                       description: 'Field type'
                     },
                     content: {
@@ -298,7 +298,7 @@ export const TOOLS: Tool[] = [
                     fieldId: { type: 'string', description: 'Field ID' },
                     type: {
                       type: 'string',
-                      enum: ['text', 'number', 'checkbox', 'select', 'mSelect', 'date', 'url', 'email', 'phone', 'mAsset'],
+                      enum: ['text', 'number', 'checkbox', 'select', 'mSelect', 'date', 'url', 'email', 'phone', 'mAsset', 'relation'],
                       description: 'Field type'
                     },
                     content: { description: 'New value' }
@@ -331,6 +331,153 @@ export const TOOLS: Tool[] = [
     }
   },
   {
+    name: 'list_views',
+    description: 'List database views and their current layout/group/filter/sort configuration.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        avId: { type: 'string', description: 'Database ID' }
+      },
+      required: ['avId']
+    }
+  },
+  {
+    name: 'add_view',
+    description: 'Add a new table, kanban, or gallery view to a database.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        avId: { type: 'string', description: 'Database ID' },
+        type: { type: 'string', enum: ['table', 'kanban', 'gallery'], description: 'View type' },
+        name: { type: 'string', description: 'View name' },
+        groupByFieldId: { type: 'string', description: 'Field ID to group by, typically for kanban' },
+        filters: { type: 'array', items: { type: 'object' }, description: 'Raw SiYuan view filters' },
+        sorts: { type: 'array', items: { type: 'object' }, description: 'Raw SiYuan view sorts' }
+      },
+      required: ['avId', 'type', 'name']
+    }
+  },
+  {
+    name: 'update_view',
+    description: 'Update an existing database view layout, name, grouping, filters, or sorts.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        avId: { type: 'string', description: 'Database ID' },
+        viewId: { type: 'string', description: 'View ID' },
+        type: { type: 'string', enum: ['table', 'kanban', 'gallery'], description: 'New view type' },
+        name: { type: 'string', description: 'New view name' },
+        groupByFieldId: { type: 'string', description: 'Field ID to group by' },
+        filters: { type: 'array', items: { type: 'object' }, description: 'Raw SiYuan view filters' },
+        sorts: { type: 'array', items: { type: 'object' }, description: 'Raw SiYuan view sorts' }
+      },
+      required: ['avId', 'viewId']
+    }
+  },
+  {
+    name: 'delete_view',
+    description: 'Delete a database view by ID.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        avId: { type: 'string', description: 'Database ID' },
+        viewId: { type: 'string', description: 'View ID' }
+      },
+      required: ['avId', 'viewId']
+    }
+  },
+  {
+    name: 'bind_row_to_doc',
+    description: 'Convert an existing detached row into a document-backed row bound to an existing document.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        avId: { type: 'string', description: 'Database ID' },
+        entryId: { type: 'string', description: 'Existing row entry ID' },
+        docId: { type: 'string', description: 'Existing document block ID' }
+      },
+      required: ['avId', 'entryId', 'docId']
+    }
+  },
+  {
+    name: 'create_doc_backed_row',
+    description: 'Create a new document and add it to the database as a document-backed row.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        avId: { type: 'string', description: 'Database ID' },
+        notebookId: { type: 'string', description: 'Notebook ID where the document will be created' },
+        path: { type: 'string', description: 'Document path to create' },
+        title: { type: 'string', description: 'Document title' },
+        content: { type: 'string', description: 'Initial markdown body' },
+        values: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              fieldId: { type: 'string' },
+              type: {
+                type: 'string',
+                enum: ['text', 'number', 'checkbox', 'select', 'mSelect', 'date', 'url', 'email', 'phone', 'mAsset', 'relation']
+              },
+              content: {}
+            },
+            required: ['fieldId', 'type', 'content']
+          }
+        }
+      },
+      required: ['avId', 'notebookId', 'path', 'title']
+    }
+  },
+  {
+    name: 'list_select_options',
+    description: 'List the current options for a select or multi-select database field.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        avId: { type: 'string', description: 'Database ID' },
+        fieldId: { type: 'string', description: 'Field ID' }
+      },
+      required: ['avId', 'fieldId']
+    }
+  },
+  {
+    name: 'set_select_options',
+    description: 'Set or update the available options for a select or multi-select database field.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        avId: { type: 'string', description: 'Database ID' },
+        fieldId: { type: 'string', description: 'Field ID' },
+        options: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', description: 'Option name' },
+              color: { type: 'string', description: 'Option color' },
+              desc: { type: 'string', description: 'Option description' }
+            },
+            required: ['name']
+          }
+        }
+      },
+      required: ['avId', 'fieldId', 'options']
+    }
+  },
+  {
+    name: 'rename_notebook',
+    description: 'Rename a notebook by ID.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        notebookId: { type: 'string', description: 'Notebook ID' },
+        name: { type: 'string', description: 'New notebook name' }
+      },
+      required: ['notebookId', 'name']
+    }
+  },
+  {
     name: 'manage_db_fields',
     description:
       'Add or remove fields (columns) in a database. ' +
@@ -347,8 +494,32 @@ export const TOOLS: Tool[] = [
         name: { type: 'string', description: 'Field name (required for add)' },
         type: {
           type: 'string',
-          enum: ['text', 'number', 'select', 'mSelect', 'date', 'checkbox', 'url', 'email', 'phone', 'mAsset'],
+          enum: ['text', 'number', 'select', 'mSelect', 'date', 'checkbox', 'url', 'email', 'phone', 'mAsset', 'relation', 'rollup'],
           description: 'Field type (required for add)'
+        },
+        relation: {
+          type: 'object',
+          properties: {
+            targetAvId: { type: 'string', description: 'Target database ID for relation fields' },
+            backRef: { type: 'boolean', description: 'Create the reverse relation field automatically' },
+            backRefName: { type: 'string', description: 'Name for the reverse relation field' }
+          },
+          required: ['targetAvId'],
+          description: 'Required when adding a relation field'
+        },
+        rollup: {
+          type: 'object',
+          properties: {
+            relationFieldId: { type: 'string', description: 'Relation field ID on this database' },
+            targetFieldId: { type: 'string', description: 'Target field ID on the related database' },
+            calc: {
+              type: 'string',
+              enum: ['count', 'countDistinct', 'sum', 'avg', 'min', 'max', 'empty', 'notEmpty', 'unique', 'checked', 'unchecked', 'percent'],
+              description: 'Rollup calculation type'
+            }
+          },
+          required: ['relationFieldId', 'targetFieldId'],
+          description: 'Required when adding a rollup field'
         },
         fieldId: { type: 'string', description: 'Field ID to remove (required for remove)' }
       },

--- a/src/tools/v2/handlers.ts
+++ b/src/tools/v2/handlers.ts
@@ -59,6 +59,24 @@ export async function handleToolCall(name: string, args: any): Promise<StandardR
       return handleUpdateDbCells(args);
     case 'delete_db_rows':
       return handleDeleteDbRows(args);
+    case 'list_views':
+      return handleListViews(args);
+    case 'add_view':
+      return handleAddView(args);
+    case 'update_view':
+      return handleUpdateView(args);
+    case 'delete_view':
+      return handleDeleteView(args);
+    case 'bind_row_to_doc':
+      return handleBindRowToDoc(args);
+    case 'create_doc_backed_row':
+      return handleCreateDocBackedRow(args);
+    case 'list_select_options':
+      return handleListSelectOptions(args);
+    case 'set_select_options':
+      return handleSetSelectOptions(args);
+    case 'rename_notebook':
+      return handleRenameNotebook(args);
     case 'manage_db_fields':
       return handleManageDbFields(args);
 
@@ -328,6 +346,73 @@ async function handleDeleteDbRows(args: any): Promise<StandardResponse> {
   });
 }
 
+async function handleListViews(args: any): Promise<StandardResponse> {
+  const views = await avService.listViews(args.avId);
+  return createStandardResponse(true, `${views.length} view(s) found`, views);
+}
+
+async function handleAddView(args: any): Promise<StandardResponse> {
+  const view = await avService.addView(args.avId, args);
+  return createStandardResponse(true, `View "${view.name}" added`, view);
+}
+
+async function handleUpdateView(args: any): Promise<StandardResponse> {
+  const view = await avService.updateView(args.avId, args.viewId, args);
+  return createStandardResponse(true, `View "${view.name}" updated`, view);
+}
+
+async function handleDeleteView(args: any): Promise<StandardResponse> {
+  await avService.deleteView(args.avId, args.viewId);
+  return createStandardResponse(true, 'View deleted', { avId: args.avId, viewId: args.viewId });
+}
+
+async function handleBindRowToDoc(args: any): Promise<StandardResponse> {
+  const row = await avService.bindRowToDoc(args.avId, args.entryId, args.docId);
+  return createStandardResponse(true, 'Row bound to document', row);
+}
+
+async function handleCreateDocBackedRow(args: any): Promise<StandardResponse> {
+  const row = await avService.createDocBackedRow(
+    args.avId,
+    args.notebookId,
+    args.path,
+    args.title,
+    args.content || '',
+    args.values || []
+  );
+  return createStandardResponse(true, 'Document-backed row created', row);
+}
+
+async function handleListSelectOptions(args: any): Promise<StandardResponse> {
+  const options = await avService.listSelectOptions(args.avId, args.fieldId);
+  return createStandardResponse(true, `${options.length} option(s) found`, options);
+}
+
+async function handleSetSelectOptions(args: any): Promise<StandardResponse> {
+  const options = await avService.setSelectOptions(args.avId, args.fieldId, args.options);
+  return createStandardResponse(true, `${options.length} option(s) set`, options);
+}
+
+async function handleRenameNotebook(args: any): Promise<StandardResponse> {
+  if (!args.notebookId?.trim() || !args.name?.trim()) {
+    return createStandardResponse(false, 'notebookId and name required', null, 'Provide notebookId and name');
+  }
+
+  const resp = await client.request('/api/notebook/renameNotebook', {
+    notebook: args.notebookId.trim(),
+    name: args.name.trim()
+  });
+
+  if (!resp || resp.code !== 0) {
+    return createStandardResponse(false, 'Failed to rename notebook', null, resp?.msg ?? 'Unknown error');
+  }
+
+  return createStandardResponse(true, 'Notebook renamed', {
+    notebookId: args.notebookId.trim(),
+    name: args.name.trim()
+  });
+}
+
 async function handleManageDbFields(args: any): Promise<StandardResponse> {
   if (!args.avId?.trim()) {
     return createStandardResponse(false, 'Database ID required', null, 'avId is missing');
@@ -337,6 +422,20 @@ async function handleManageDbFields(args: any): Promise<StandardResponse> {
     case 'add': {
       if (!args.name?.trim() || !args.type?.trim()) {
         return createStandardResponse(false, 'name and type required for add', null, 'Provide name and type');
+      }
+      if (args.type === 'relation') {
+        if (!args.relation?.targetAvId?.trim()) {
+          return createStandardResponse(false, 'relation.targetAvId required', null, 'Provide relation.targetAvId for relation fields');
+        }
+        const field = await avService.createRelationField(args.avId, args.name, args.relation);
+        return createStandardResponse(true, `Field "${field.name}" added`, field);
+      }
+      if (args.type === 'rollup') {
+        if (!args.rollup?.relationFieldId?.trim() || !args.rollup?.targetFieldId?.trim()) {
+          return createStandardResponse(false, 'rollup config required', null, 'Provide rollup.relationFieldId and rollup.targetFieldId for rollup fields');
+        }
+        const field = await avService.createRollupField(args.avId, args.name, args.rollup);
+        return createStandardResponse(true, `Field "${field.name}" added`, field);
       }
       const field = await avService.createField(args.avId, args.name, args.type);
       return createStandardResponse(true, `Field "${field.name}" added`, field);

--- a/src/utils/avParser.test.ts
+++ b/src/utils/avParser.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { parseCellValue, parseColumns } from './avParser';
+
+describe('avParser', () => {
+  it('parses relation cell values', () => {
+    const result = parseCellValue({
+      value: {
+        type: 'relation',
+        relation: {
+          blockIDs: ['row-b'],
+          contents: [{ block: { content: 'Target Row' } }]
+        }
+      }
+    });
+
+    expect(result).toEqual({
+      ids: ['row-b'],
+      contents: [{ block: { content: 'Target Row' } }]
+    });
+  });
+
+  it('preserves field metadata for options, relation, and rollup', () => {
+    const columns = parseColumns([
+      {
+        id: 'status',
+        name: 'Status',
+        type: 'select',
+        options: [{ name: 'Todo', color: '1' }]
+      },
+      {
+        id: 'repo',
+        name: 'Repo',
+        type: 'relation',
+        relation: { avID: 'repos-db', isTwoWay: true, backKeyID: 'tasks' }
+      },
+      {
+        id: 'repo_count',
+        name: 'Repo Count',
+        type: 'rollup',
+        rollup: { relationKeyID: 'repo', keyID: 'name', calc: { operator: 'CountAll' } }
+      }
+    ]);
+
+    expect(columns).toEqual([
+      {
+        id: 'status',
+        name: 'Status',
+        type: 'select',
+        options: [{ name: 'Todo', color: '1' }],
+        relation: undefined,
+        rollup: undefined
+      },
+      {
+        id: 'repo',
+        name: 'Repo',
+        type: 'relation',
+        options: undefined,
+        relation: { avID: 'repos-db', isTwoWay: true, backKeyID: 'tasks' },
+        rollup: undefined
+      },
+      {
+        id: 'repo_count',
+        name: 'Repo Count',
+        type: 'rollup',
+        options: undefined,
+        relation: undefined,
+        rollup: { relationKeyID: 'repo', keyID: 'name', calc: { operator: 'CountAll' } }
+      }
+    ]);
+  });
+});

--- a/src/utils/avParser.ts
+++ b/src/utils/avParser.ts
@@ -56,8 +56,13 @@ export function parseCellValue(cell: any): any {
     case 'updated':
       return v[v.type]?.content ?? null;
 
-    case 'rollup':
-      return v.rollup?.content ?? null;
+    case 'rollup': {
+      const contents = v.rollup?.contents ?? [];
+      if (contents.length === 1 && contents[0]?.type === 'number') {
+        return contents[0]?.number?.content ?? null;
+      }
+      return contents;
+    }
 
     case 'template':
       // Template column: computed read-only string
@@ -115,13 +120,16 @@ export function findColumn(
 /**
  * Convertit une liste brute de colonnes SiYuan en format normalisé.
  */
-export function parseColumns(rawColumns: any[]): Array<{ id: string; name: string; type: string }> {
+export function parseColumns(rawColumns: any[]): Array<{ id: string; name: string; type: string; options?: any[]; relation?: any; rollup?: any }> {
   return (rawColumns ?? [])
     .filter((col: any) => col?.id)
     .map((col: any) => ({
       id: col.id,
       name: col.name ?? col.id,
-      type: col.type ?? 'text'
+      type: col.type ?? 'text',
+      options: col.options ?? undefined,
+      relation: col.relation ?? undefined,
+      rollup: col.rollup ?? undefined
     }));
 }
 
@@ -131,7 +139,7 @@ export function parseColumns(rawColumns: any[]): Array<{ id: string; name: strin
  */
 export function parseRow(
   row: any,
-  columns: Array<{ id: string; name: string; type: string }>
+  columns: Array<{ id: string; name: string; type: string; options?: any[]; relation?: any; rollup?: any }>
 ): { id: string; cells: Record<string, any> } {
   const cells: Record<string, any> = {};
   const rawCells: any[] = row.cells ?? [];


### PR DESCRIPTION
## Summary
- add relation and rollup field creation, view CRUD/config, select option management, notebook rename, and document-backed row flows to the MCP server
- harden AV row discovery so grouped or kanban views do not hide newly-created or rebound rows from MCP consumers
- add focused tests plus a live `npm run smoke:siyuan` script, and update the README with the new tools and consumer verification steps

## Test plan
- [x] `npm run build`
- [x] `npm test`
- [x] `SIYUAN_API_TOKEN=<local token> npm run smoke:siyuan` against local SiYuan 3.6.4

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)